### PR TITLE
Remove relative path from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ledger-parser = { path = "../rust-ledger-parser", version = "4" }
+ledger-parser = "4"
 rust_decimal = "1"
 chrono = "0.4"


### PR DESCRIPTION
Sample workspace Cargo.toml to use instead:
```
[workspace]

members = [
    "rust-ledger-parser",
    "rust-ledger-utils",
]

[patch.crates-io]
ledger-parser = { path = "rust-ledger-parser" }
ledger-utils = { path = "rust-ledger-utils" }
```